### PR TITLE
Fix codec error installing from source on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup, find_packages
 
 # read the contents of your README file
 ROOT = pathlib.Path(__file__).parent
-README = (ROOT / "README.md").read_text()
+README = (ROOT / "README.md").read_text(encoding = 'utf-8')
 
 # extract version from __init__.py
-with open(ROOT / "pysocialforce/__init__.py", "r") as f:
+with open(ROOT / "pysocialforce/__init__.py", "r", encoding = 'utf-8') as f:
     VERSION_LINE = [l for l in f if l.startswith("__version__")][0]
     VERSION = VERSION_LINE.split("=")[1].strip()[1:-1]
 


### PR DESCRIPTION
Hello, I found an error when installing from source on Windows platform. It regards to the codec issue. 
This is the error when I perform the command.
`pip install -e '.[test,plot]'`

```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\me\PySocialForce-master\setup.py", line 6, in <module>
        README = (ROOT / "README.md").read_text()
      File "c:\programdata\anaconda3\lib\pathlib.py", line 1233, in read_text
        return f.read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 6095: illegal multibyte sequence
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```


I fixed the issue by manually adding encoding methods when reading the file. If this is helpful, you can directly merge my version of setup.py. Hope it's helpful for you.